### PR TITLE
[19866] Remove the foundation import

### DIFF
--- a/app/assets/stylesheets/my_project_page/my_projects_overview.sass
+++ b/app/assets/stylesheets/my_project_page/my_projects_overview.sass
@@ -16,19 +16,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // See doc/COPYRIGHT.md for more details.
-@import foundation
 
 div.overview
   padding: 6px
   margin-bottom: 10px
   line-height: 1.5em
-
-#visible-grid
-  .block-receiver
-    @extend .grid-content
-    min-height: 32px
-    // TODO: this fixes an issue which currently breaks the layout
-    // It has to be removed once it is fixed upstream
-    // @see https://github.com/zurb/foundation-apps/issues/575
-    &.left, &.right
-      @extend .medium-6


### PR DESCRIPTION
This removes the foundation import in the plugin css, which caused major design issues with the project overview page.

Dependent classes have been moved to core