### PR TITLE
[19871] Fix frontend rendering

### DIFF
--- a/app/helpers/my_projects_overviews_helper.rb
+++ b/app/helpers/my_projects_overviews_helper.rb
@@ -48,12 +48,21 @@ module MyProjectsOverviewsHelper
       :'ajax-url' => ajax_url(name),
       position: name
     }
+    construct_blocks(name: name, css_classes: css_classes, data: data)
+  end
+
+  def rendered_field(name)
+    construct_blocks(name: name, css_classes: Array(name))
+  end
+
+  protected
+
+  def construct_blocks(opts = {})
+    name, css_classes, data = [:name, :css_classes, :data].map { |sym| opts.fetch sym, '' }
     content_tag :div, id: "list-#{name}", class: css_classes, data: data do
       ActiveSupport::SafeBuffer.new(blocks[name].map { |b| construct b }.join)
     end
   end
-
-  protected
 
   def block_available?(block)
     controller.class.available_blocks.keys.include? block

--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -19,6 +19,14 @@ See doc/COPYRIGHT.md for more details.
 
 ++#%>
 
+<% content_for :header_tags do %>
+  <%= javascript_include_tag "my_project_page/my_project_page" %>
+  <%= auto_discovery_link_tag(:atom, {:controller => 'activities',  :action => 'index', :id => @project, :format => 'atom', :key => User.current.rss_key}) %>
+  <%= stylesheet_link_tag "my_project_page/my_projects_overview", :media => 'all' %>
+<% end %>
+
+<% html_title(l(:label_overview)) -%>
+
 <h2><%=l(:label_overview)%></h2>
 
 <% content_for :toolbar do %>
@@ -74,11 +82,3 @@ See doc/COPYRIGHT.md for more details.
   <% end %>
   <%= call_hook(:view_projects_show_sidebar_bottom, :project => project) %>
 <% end %>
-
-<% content_for :header_tags do %>
-  <%= javascript_include_tag "my_project_page/my_project_page" %>
-  <%= auto_discovery_link_tag(:atom, {:controller => 'activities',  :action => 'index', :id => @project, :format => 'atom', :key => User.current.rss_key}) %>
-  <%= stylesheet_link_tag "my_project_page/my_projects_overview", :media => 'all' %>
-<% end %>
-
-<% html_title(l(:label_overview)) -%>

--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -47,25 +47,18 @@ See doc/COPYRIGHT.md for more details.
 <% end %>
 <%= render :partial => 'layouts/toolbar' %>
 
-<% ['top', 'left', 'right'].each do |position| %>
-  <div id="list-<%= position %>" class="splitcontent<%= position %>">
-    <% blocks[position].each do |b| %>
-      <div class="mypage-box" id='<%=b.respond_to?(:to_ary) ? "widget_teaser_#{b[0]}" : "widget_#{b}" %>'>
-        <div class="wiki">
-          <% if MyProjectsOverviewsController.available_blocks.keys.include? b %>
-            <%= render :partial => "my_projects_overviews/blocks/#{b}" %>
-          <% elsif b.respond_to? :to_ary %>
-            <%= render :partial => "textilizable",
-                       :locals => { :project => project,
-                                    :user => user,
-                                    :block_title => b[1],
-                                    :textile => b.last } %>
-          <% end %>
-        </div>
-      </div>
-    <% end if blocks[position] %>
+<div id="invisible-grid">
+  <div class="grid-block medium-up-1">
+    <% top_fields.each do |f| %>
+      <%= rendered_field f %>
+    <% end %>
   </div>
-<% end %>
+  <div class="grid-block medium-up-2">
+    <% middle_fields.each do |f| %>
+      <%= rendered_field f %>
+    <% end %>
+  </div>
+</div>
 
 <% content_for :sidebar do %>
   <% if total_hours.present? %>

--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -19,29 +19,25 @@ See doc/COPYRIGHT.md for more details.
 
 ++#%>
 
-<% content_for :action_menu_specific do %>
-    <%=
-      context_links = []
-      if User.current.allowed_to?(:add_subprojects, project)
-        context_links << link_to(l(:label_subproject_new),
-                                 { :controller => 'projects',
-                                   :action => 'new',
-                                   :parent_id => project },
-                                   :class => 'icon icon-add')
-      end
-      if User.current.allowed_to?(:edit_project, project)
-        context_links << link_to(l(:label_personalize_page),
-                                 { :action => 'page_layout' },
-                                   :class => 'icon icon-edit',
-                                   :accesskey => accesskey(:edit))
-      end
-      context_links.join("&nbsp;&nbsp;&nbsp;").html_safe
-    %>
-<% end %>
-
 <h2><%=l(:label_overview)%></h2>
 
-<%= render :partial => 'layouts/action_menu_specific' %>
+<% content_for :toolbar do %>
+  <% if User.current.allowed_to?(:add_subprojects, project) %>
+    <li class="toolbar-item">
+      <%= link_to new_project_path(parent_id: project), class: 'button -highlight' do %>
+        <i class="icon-add"></i> <%= l(:label_subproject_new) %>
+      <% end %>
+    </li>
+  <% end %>
+  <% if User.current.allowed_to?(:edit_project, project) %>
+    <li class="toolbar-item">
+      <%= link_to my_projects_overview_path(project), class: 'button', accesskey: accesskey(:edit) do %>
+        <i class="icon-edit"></i> <%= l(:label_personalize_page) %>
+      <% end %>
+    </li>
+  <% end %>
+<% end %>
+<%= render :partial => 'layouts/toolbar' %>
 
 <% ['top', 'left', 'right'].each do |position| %>
   <div id="list-<%= position %>" class="splitcontent<%= position %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ OpenProject::Application.routes.draw do
 
 
 
-  get  'my_projects_overview/:id/page_layout',                        to: "my_projects_overviews#page_layout"
+  get  'my_projects_overview/:id/page_layout',                        to: "my_projects_overviews#page_layout", as: :my_projects_overview
   post 'my_projects_overview/:id/page_layout/order_blocks',           to: "my_projects_overviews#order_blocks"
   post 'my_projects_overview/:id/page_layout/remove_block',           to: "my_projects_overviews#remove_block"
   post 'my_projects_overview/:id/page_layout/add_block',              to: "my_projects_overviews#add_block"


### PR DESCRIPTION
This fixes an issue documented in https://community.openproject.org/work_packages/19871. 

This should fix the rendered blocks of the project overview and provide a two-column layout where a two-column layout was desired for.

**:warning: The functionality of this PR depends on https://github.com/opf/openproject/pull/2961 :warning:**