### PR TITLE
remove details on spent time from project overview

### DIFF
--- a/app/controllers/my_projects_overviews_controller.rb
+++ b/app/controllers/my_projects_overviews_controller.rb
@@ -256,15 +256,6 @@ class MyProjectsOverviewsController < ApplicationController
     @all_roles = Role.all
   end
 
-  def total_hours
-    if User.current.allowed_to?(:view_time_entries, project) ||
-       # granted, this is a dirty hack
-       Redmine::Plugin.installed?(:openproject_costs) && User.current.allowed_to?(:view_own_time_entries, project)
-
-      @total_hours ||= TimeEntry.visible.sum(:hours, :include => :project, :conditions => subproject_condition).to_f
-    end
-  end
-
   def project
     @project
   end

--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -56,19 +56,3 @@ See doc/COPYRIGHT.md for more details.
     <% end %>
   </div>
 </div>
-
-<% content_for :sidebar do %>
-  <% if total_hours.present? %>
-    <h3><%= l(:label_spent_time) %></h3>
-    <p><span class="icon icon-time"><%= l_hours(total_hours) %></span></p>
-    <p>
-      <%= link_to(l(:label_details), {:controller => 'timelog', :action => 'index', :project_id => project}) %> |
-
-      <%= link_to(l(:label_report), {:controller => 'time_entry_reports', :action => 'report', :project_id => project}) %>
-      <% if authorize_for('timelog', 'new') %>
-        | <%= link_to l(:button_log_time), {:controller => 'timelog', :action => 'new', :project_id => project} %>
-      <% end %>
-    </p>
-  <% end %>
-  <%= call_hook(:view_projects_show_sidebar_bottom, :project => project) %>
-<% end %>


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/20219

## Description

This PR removes details on the spent time from the overview page of a project.

## Related PRs

This PR should be merged together with the following other PRs:

* https://github.com/opf/openproject/pull/3114
* https://github.com/finnlabs/openproject-reporting/pull/60