### PR TITLE
[19972] Remove the `new subproject` link from project overview

### DIFF
--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -28,17 +28,10 @@ See doc/COPYRIGHT.md for more details.
 <% html_title(l(:label_overview)) -%>
 
 <%= toolbar title: l(:label_overview) do %>
-  <% if User.current.allowed_to?(:add_subprojects, project) %>
-    <li class="toolbar-item">
-      <%= link_to new_project_path(parent_id: project), class: 'button -alt-highlight' do %>
-        <i class="icon-add"></i> <%= l(:label_subproject_new) %>
-      <% end %>
-    </li>
-  <% end %>
   <% if User.current.allowed_to?(:edit_project, project) %>
-    <li class="toolbar-item">
+    <li class="toolbar-item" title="<%= l(:label_personalize_page) %>">
       <%= link_to my_projects_overview_path(project), class: 'button', accesskey: accesskey(:edit) do %>
-        <i class="icon-edit"></i> <%= l(:label_personalize_page) %>
+        <i class="icon-settings"></i>
       <% end %>
     </li>
   <% end %>

--- a/app/views/my_projects_overviews/index.html.erb
+++ b/app/views/my_projects_overviews/index.html.erb
@@ -32,6 +32,7 @@ See doc/COPYRIGHT.md for more details.
     <li class="toolbar-item" title="<%= l(:label_personalize_page) %>">
       <%= link_to my_projects_overview_path(project), class: 'button', accesskey: accesskey(:edit) do %>
         <i class="icon-settings"></i>
+        <span class="hidden-for-sighted"><%= l(:label_personalize_page) %></span>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
Also reduces the personalize page button to the settings gear icon.

Related PR in core: https://github.com/opf/openproject/pull/3136.

Should meet the requirements of https://community.openproject.org/work_packages/19972