### PR TITLE
[21317] add checks around the actions for each block

### DIFF
--- a/app/views/my_projects_overviews/_block.html.erb
+++ b/app/views/my_projects_overviews/_block.html.erb
@@ -24,12 +24,14 @@ See doc/COPYRIGHT.md for more details.
   <% block_name_id = "my_page_#{block_name}_box_actions" %>
   <% content_for block_name_id do %>
     <div class="box-actions">
+      <% if User.current.allowed_to?(:remove_block, nil, global: true) %>
       <%= link_to_remote l(:button_delete), {
             :confirm => l(:label_confirm_delete),
             :url => { :action => "remove_block", :block => block_name },
             :class => "icon icon-delete"
           }
           %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/my_projects_overviews/_block_textilizable.html.erb
+++ b/app/views/my_projects_overviews/_block_textilizable.html.erb
@@ -49,14 +49,17 @@ See doc/COPYRIGHT.md for more details.
       </div>
       <div id="<%= block_name %>-preview-div" class="wiki">
         <div class="box-actions">
-          <a href="#" class="icon icon-edit edit-textilizable" data-block-name="<%= block_name %>"><%= l(:button_edit) %></a>
-
-          <%= link_to_remote l(:button_delete), {
-                :confirm => l(:label_confirm_delete),
+          <% unless User.current.anonymous? %>
+            <a href="#" class="icon icon-edit edit-textilizable" data-block-name="<%= block_name %>"><%= l(:button_edit) %></a>
+          <% end %>
+          <% if User.current.allowed_to?(:remove_block, nil, global: true) %>
+            <%= link_to_remote l(:button_delete), {
+                  :confirm => l(:label_confirm_delete),
                 :url => { :action => "remove_block", :block => block_name },
                 :class => "icon icon-delete"
               }
-              %>
+            %>
+          <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
This will add checking for the `AnonymousUser` for the actions in a block. Also, it will add checks to see if the block can be removed or not by the user (this may be a moot point).

Otherwise, the `AnonymousUser` can see faulty actions for each block inserted.