### PR TITLE
Fix syntax error with hash

### DIFF
--- a/app/helpers/my_projects_overviews_helper.rb
+++ b/app/helpers/my_projects_overviews_helper.rb
@@ -45,7 +45,7 @@ module MyProjectsOverviewsHelper
   def grid_field(name)
     css_classes = %w(block-receiver list-position) + [name]
     data = {
-      'ajax-url': ajax_url(name),
+      'ajax-url' => ajax_url(name),
       position: name
     }
     construct_blocks(name: name, css_classes: css_classes, data: data)


### PR DESCRIPTION
Introduced by rubocop auto-correct feature.