### PR TITLE
[21989] Buttons on project overview page covered up by scroll bar in widgets

### DIFF
--- a/app/views/my_projects_overviews/blocks/_work_packages_assigned_to_me.html.erb
+++ b/app/views/my_projects_overviews/blocks/_work_packages_assigned_to_me.html.erb
@@ -35,11 +35,11 @@ See doc/COPYRIGHT.md for more details.
                             .order("#{IssuePriority.table_name}.position DESC, #{WorkPackage.table_name}.updated_at DESC") %>
 <%= render partial: 'work_packages/list_simple', :locals => { :work_packages => assigned_work_packages, list_for: :assigned } %>
 <% if assigned_work_packages.length > 0 %>
-  <p class="small">
+  <div class="generic-table--action-buttons">
     <%= link_to l(:label_work_package_view_all_assigned_to_me),
                   project_work_packages_assigned_to_me_path(@project),
                   :class => 'button -highlight' %>
-  </p>
+  </div>
 <% end %>
 
 <% content_for :header_tags do %>

--- a/app/views/my_projects_overviews/blocks/_work_packages_reported_by_me.html.erb
+++ b/app/views/my_projects_overviews/blocks/_work_packages_reported_by_me.html.erb
@@ -35,11 +35,11 @@ See doc/COPYRIGHT.md for more details.
                             .order("#{WorkPackage.table_name}.updated_at DESC") %>
 <%= render :partial => 'work_packages/list_simple', :locals => { :work_packages => reported_work_packages, list_for: :reported } %>
 <% if reported_work_packages.length > 0 %>
-  <p class="small">
+  <div class="generic-table--action-buttons">
     <%= link_to l(:label_work_package_view_all_reported_by_me),
                   project_work_packages_reported_by_me_path(@project),
                   :class => 'button -highlight' %>
-  </p>
+  </div>
 <% end %>
 
 <% content_for :header_tags do %>

--- a/app/views/my_projects_overviews/blocks/_work_packages_responsible_for.html.erb
+++ b/app/views/my_projects_overviews/blocks/_work_packages_responsible_for.html.erb
@@ -35,11 +35,11 @@ See doc/COPYRIGHT.md for more details.
                                .order("#{IssuePriority.table_name}.position DESC, #{WorkPackage.table_name}.updated_at DESC") %>
 <%= render :partial => 'work_packages/list_simple', :locals => { :work_packages => responsible_work_packages, list_for: :responsible } %>
 <% if responsible_work_packages.length > 0 %>
-  <p class="small">
+  <div class="generic-table--action-buttons">
     <%= link_to l(:label_work_package_view_all_responsible_for),
                   project_work_packages_responsible_for_path(@project),
                   :class => 'button -highlight' %>
-  </p>
+  </div>
 <% end %>
 
 <% content_for :header_tags do %>

--- a/app/views/my_projects_overviews/blocks/_work_packages_watched.html.erb
+++ b/app/views/my_projects_overviews/blocks/_work_packages_watched.html.erb
@@ -32,9 +32,9 @@ See doc/COPYRIGHT.md for more details.
 
 <%= render :partial => 'work_packages/list_simple', :locals => { :work_packages => watched_work_packages, list_for: :watched } %>
 <% if watched_work_packages.length > 0 %>
-  <p class="small">
+  <div class="generic-table--action-buttons">
     <%= link_to l(:label_work_package_view_all_watched),
                   project_work_packages_watched_path(@project),
                   :class => 'button -highlight' %>
-  </p>
+  </div>
 <% end %>


### PR DESCRIPTION
This applies the class 'generic-table--action-buttons' in the my_project_page plugin. Thus the buttons get a greater distance to the table and overlapping elements are avoided.

https://community.openproject.org/work_packages/21989/activity#