### PR TITLE
[11611] Personalize this page: Consistent Wording of the same functionality (my project page plugin)

### DIFF
--- a/app/views/my_projects_overviews/page_layout.html.erb
+++ b/app/views/my_projects_overviews/page_layout.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.md for more details.
     %>
     <% end %>
   </li>
-  <li class="toolbar-item"><%= link_to l(:button_back), {:action => 'index'}, class: 'button' %></li>
+  <li class="toolbar-item"><%= link_to l(:button_save_back), {:action => 'index'}, class: 'button' %></li>
 <% end %>
 
 


### PR DESCRIPTION
This changes the labeling of the button to 'Save and back' in the personalize my page section.

The required PR in the core can be found here: https://github.com/opf/openproject/pull/4142

https://community.openproject.org/work_packages/11611/activity