### PR TITLE
[22970] Missing button and wrong link on members button on project overview

### DIFF
--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,0 +1,7 @@
+# Used by travis to bundle this plugin with the OpenProject core.
+# The tested plugin will be moved to the path `./plugins/this`
+# whereas OpenProject will be checked out to `.`.
+
+gem 'openproject-my_project_page', path: 'plugins/this'
+
+# If the plugin has any dependencies declare them here:

--- a/app/views/my_projects_overviews/blocks/_members.html.erb
+++ b/app/views/my_projects_overviews/blocks/_members.html.erb
@@ -25,7 +25,7 @@ See doc/COPYRIGHT.md for more details.
 
 <h3 class="widget-box--header">
   <span class="icon-context icon-group"></span>
-  <span class="widget-box--header-title"><%=l(:label_member_plural)%></span>
+  <span class="widget-box--header-title"><%=t(:label_member_plural)%></span>
 </h3>
 
 <% if @project.members.count > 0 && users_by_role(50).any? %>
@@ -44,10 +44,10 @@ See doc/COPYRIGHT.md for more details.
       <% end %>
     </p>
   </div>
-  <% if current_user.admin? %>
-    <%= link_to new_user_path, class: 'button -alt-highlight' do %>
-      <i class="button--icon icon-add"></i>
-      <span class="button--text"><%= l('activerecord.models.member') %></span>
-    <% end %>
+<% end %>
+<% if current_user.admin? %>
+  <%= link_to new_project_member_path(project_id: project.identifier), class: 'button -alt-highlight' do %>
+    <i class="button--icon icon-add"></i>
+    <span class="button--text"><%= t('activerecord.models.member') %></span>
   <% end %>
 <% end %>


### PR DESCRIPTION
This changes the condition and link of the 'add member' button on the project overview page. The button is now shown even if there are no members in the project. Further the link was corrected. It directs now to the project member page, before it was the admin user page.

https://community.openproject.com/work_packages/22970/activity