### PR TITLE
Mark textarea content for macros html_safe

### DIFF
--- a/app/views/my_projects_overviews/_block_textilizable.html.erb
+++ b/app/views/my_projects_overviews/_block_textilizable.html.erb
@@ -37,7 +37,7 @@ See doc/COPYRIGHT.md for more details.
 
               <%= hidden_field_tag 'block_name', block_name %>
               <%= text_field_tag "block_title_#{block_name}", block_title %>
-              <%= text_area_tag "textile_#{block_name}", textile, cols: 40, rows: 5, class: 'wiki-edit' %>
+              <%= text_area_tag "textile_#{block_name}", textile.html_safe, cols: 40, rows: 5, class: 'wiki-edit' %>
               <%= wikitoolbar_for "textile_#{block_name}" %>
             <p><label><%=l(:label_attachment_plural)%></label><br />
               <%= render partial: 'attachments/form' %>

--- a/app/views/my_projects_overviews/_textilizable.html.erb
+++ b/app/views/my_projects_overviews/_textilizable.html.erb
@@ -29,8 +29,8 @@ See doc/COPYRIGHT.md for more details.
 
 <% if defined? block_name %>
   <div id="<%= block_name %>-text">
-    <%= textilizable(textile, :object => overview) %>
+    <%= format_text(textile, :object => overview) %>
   </div>
 <% else %>
-  <%= textilizable(textile, :object => overview) %>
+  <%= format_text(textile, :object => overview) %>
 <% end %>


### PR DESCRIPTION
Otherwise, they will be escaped despite not being executed.