### PR TITLE
[23980] Add buttons are not consistently used (My Project Page)

### DIFF
--- a/app/views/my_projects_overviews/blocks/_members.html.erb
+++ b/app/views/my_projects_overviews/blocks/_members.html.erb
@@ -46,7 +46,10 @@ See doc/COPYRIGHT.md for more details.
   </div>
 <% end %>
 <% if current_user.admin? %>
-  <%= link_to new_project_member_path(project_id: project.identifier), class: 'button -alt-highlight' do %>
+  <%= link_to new_project_member_path(project_id: project.identifier),
+        { class: 'button -alt-highlight',
+          title: t(:button_add_member),
+          aria: { label: t(:button_add_member) }} do %>
     <i class="button--icon icon-add"></i>
     <span class="button--text"><%= t('activerecord.models.member') %></span>
   <% end %>

--- a/app/views/my_projects_overviews/blocks/_news_latest.html.erb
+++ b/app/views/my_projects_overviews/blocks/_news_latest.html.erb
@@ -37,7 +37,10 @@ See doc/COPYRIGHT.md for more details.
                   :action => 'index',
                   :project_id => project},
                   :class => 'button -highlight' %>
-      <%= link_to new_project_news_path(@project), class: 'button -alt-highlight' do %>
+      <%= link_to new_project_news_path(@project),
+            { class: 'button -alt-highlight',
+              title: t(:label_news_new),
+              aria: { label: t(:label_news_new) }} do %>
           <i class="button--icon icon-add"></i>
           <span class="button--text"><%= l('activerecord.models.news') %></span>
         <% end %>

--- a/app/views/my_projects_overviews/blocks/_work_package_tracking.html.erb
+++ b/app/views/my_projects_overviews/blocks/_work_package_tracking.html.erb
@@ -43,7 +43,10 @@ See doc/COPYRIGHT.md for more details.
       <% if User.current.allowed_to?(:view_gantt, project, :global => true) %>
         <%= link_to(l(:label_gantt), {:controller => '/gantts', :action => 'show', :project_id => project}, :class => 'button -highlight') %>
       <% end %>
-      <%= link_to new_project_work_packages_path(project), class: 'button -alt-highlight' do %>
+      <%= link_to new_project_work_packages_path(project),
+            { class: 'button -alt-highlight',
+              title: t(:label_keyboard_shortcut_new_work_package),
+              aria: { label: t(:label_keyboard_shortcut_new_work_package) }} do %>
         <i class="button--icon icon-add"></i>
         <span class="button--text"><%= l('activerecord.models.work_package') %></span>
       <% end %>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:

* https://github.com/finnlabs/openproject-backlogs/pull/230
* https://github.com/opf/openproject-documents/pull/64
* https://github.com/finnlabs/openproject-global_roles/pull/64
* https://github.com/finnlabs/openproject-meeting/pull/133
* https://github.com/finnlabs/openproject-pdf_export/pull/53
* https://github.com/opf/openproject/pull/4879