### PR TITLE
[24297] Icons overlap help menu

### DIFF
--- a/app/assets/stylesheets/my_project_page/my_projects_overview.sass
+++ b/app/assets/stylesheets/my_project_page/my_projects_overview.sass
@@ -36,6 +36,7 @@ div.overview
       position: absolute
       top: 20px
       right: 20px
+      z-index: 2
 
 
 .textile-form-wrapper


### PR DESCRIPTION
This moves the icons of teasers in the background. Because of their absolute positing they overlap at the moment other elements like the help menu. 

https://community.openproject.com/projects/openproject/work_packages/24297/activity