### PR TITLE
[24369] Lines missing for tables in project overview (teaser widget)

### DIFF
--- a/app/views/my_projects_overviews/_textilizable.html.erb
+++ b/app/views/my_projects_overviews/_textilizable.html.erb
@@ -29,7 +29,7 @@ See doc/COPYRIGHT.md for more details.
 
 <div class="textile-body" ng-hide="$ctrl.formVisible">
 <% if defined? block_name %>
-  <div id="<%= block_name %>-text">
+  <div id="<%= block_name %>-text" class="wiki">
     <%= format_text(textile, :object => overview) %>
   </div>
 <% else %>


### PR DESCRIPTION
This adds the class `wiki` to teaser elements on the my project page. Thus wiki elements like tables are correctly styled.

https://community.openproject.com/projects/telekom/work_packages/24369/activity